### PR TITLE
Support standard username/password authentication for private repositories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ cd ui && npm run dev                                            # Start developm
 5. **Security Layer** (`am.ik.kagami.config.SecurityConfig`, `am.ik.kagami.token`)
    - Form-based authentication or OIDC/OAuth2 login for web UI access
    - JWT token-based authentication for private repository access
-   - `BasicToJwtAuthorizationExchangeFilter` converts Basic auth to JWT bearer tokens
+   - `BasicToBearerTokenResolver` resolves the password part of Basic auth as a JWT bearer token (username is ignored)
    - TOKEN generation requires USER role (JWT tokens cannot generate new tokens)
    - CSRF partially disabled for `/artifacts/**` and `/token`, Remember-me enabled for form-based auth
    - Form-based auth: Default user configurable via `spring.security.user.*` properties
@@ -144,7 +144,7 @@ Current package structure:
     - `token` - JWT token generation and verification
         - `TokenSigner` - JWT signing service
         - `web.TokenController` - Token generation endpoint
-        - `web.BasicToJwtAuthorizationExchangeFilter` - Basic to Bearer token conversion
+        - `web.BasicToBearerTokenResolver` - Resolves Basic auth password as a bearer token
 - `ui/` (Frontend - React)
     - `src/components/` - Reusable UI components
         - `ui/` - Basic UI primitives (Button, Card, Alert, etc.)

--- a/README.md
+++ b/README.md
@@ -367,21 +367,20 @@ For private repositories, generate a JWT token using the web interface:
 
 **Note**: JWT tokens cannot be used to generate new tokens. You must use the web interface.
 
-Then configure Maven with the JWT token:
+Two authentication methods are supported for build tools:
+
+- **Username/Password (Basic authentication)**: the username can be any value and the password is the JWT token
+- **Bearer token**: send the JWT token in the `Authorization: Bearer` header
+
+Then configure Maven with the JWT token. With the standard username/password configuration:
 
 ```xml
 <settings>
   <servers>
     <server>
       <id>kagami-private</id>
-      <configuration>
-        <httpHeaders>
-          <property>
-            <name>Authorization</name>
-            <value>Bearer YOUR_JWT_TOKEN</value>
-          </property>
-        </httpHeaders>
-      </configuration>
+      <username>any-username</username>
+      <password>YOUR_JWT_TOKEN</password>
     </server>
   </servers>
   <profiles>
@@ -432,6 +431,22 @@ Then configure Maven with the JWT token:
 </settings>
 ```
 
+Alternatively, configure the Bearer token method by replacing the `<server>` element above with:
+
+```xml
+<server>
+  <id>kagami-private</id>
+  <configuration>
+    <httpHeaders>
+      <property>
+        <name>Authorization</name>
+        <value>Bearer YOUR_JWT_TOKEN</value>
+      </property>
+    </httpHeaders>
+  </configuration>
+</server>
+```
+
 ### Gradle Configuration
 
 #### Public Repository
@@ -446,12 +461,15 @@ repositories {
 
 #### Private Repository
 
+The examples below use the username/password method. The Bearer token method is also available
+(see the end of this section).
+
 **Groovy DSL ($HOME/.gradle/init.gradle)**
 ```gradle
 // $HOME/.gradle/init.gradle - Groovy DSL version
 
 def repoUrl = "http://localhost:8080/artifacts/private-repo"
-def repoToken = "Bearer YOUR_JWT_TOKEN"
+def repoToken = "YOUR_JWT_TOKEN"
 
 // For regular dependencies (legacy projects)
 allprojects {
@@ -459,12 +477,9 @@ allprojects {
         maven {
             url = repoUrl
             allowInsecureProtocol = true
-            authentication {
-                header(HttpHeaderAuthentication)
-            }
-            credentials(HttpHeaderCredentials) {
-                name = "Authorization"
-                value = repoToken
+            credentials {
+                username = "kagami" // can be any value
+                password = repoToken
             }
         }
         mavenCentral() // fallback
@@ -479,12 +494,9 @@ settingsEvaluated { settings ->
             maven {
                 url = repoUrl
                 allowInsecureProtocol = true
-                authentication {
-                    header(HttpHeaderAuthentication)
-                }
-                credentials(HttpHeaderCredentials) {
-                    name = "Authorization"
-                    value = repoToken
+                credentials {
+                    username = "kagami" // can be any value
+                    password = repoToken
                 }
             }
             gradlePluginPortal() // fallback
@@ -501,12 +513,9 @@ settingsEvaluated { settings ->
             maven {
                 url = repoUrl
                 allowInsecureProtocol = true
-                authentication {
-                    header(HttpHeaderAuthentication)
-                }
-                credentials(HttpHeaderCredentials) {
-                    name = "Authorization"
-                    value = repoToken
+                credentials {
+                    username = "kagami" // can be any value
+                    password = repoToken
                 }
             }
             mavenCentral()
@@ -519,24 +528,17 @@ settingsEvaluated { settings ->
 ```kotlin
 // $HOME/.gradle/init.gradle.kts - Kotlin DSL version
 
-import org.gradle.api.artifacts.repositories.PasswordCredentials
-import org.gradle.authentication.http.HttpHeaderAuthentication
-import org.gradle.kotlin.dsl.*
-
 val repoUrl = "http://localhost:8080/artifacts/private-repo"
-val repoToken = "Bearer YOUR_JWT_TOKEN"
+val repoToken = "YOUR_JWT_TOKEN"
 
 // Extension function to configure repository
 fun RepositoryHandler.addKagamiRepository() {
     maven {
         url = uri(repoUrl)
         isAllowInsecureProtocol = true
-        authentication {
-            create<HttpHeaderAuthentication>("header")
-        }
-        credentials(HttpHeaderCredentials::class) {
-            name = "Authorization"
-            value = repoToken
+        credentials {
+            username = "kagami" // can be any value
+            password = repoToken
         }
     }
 }
@@ -574,6 +576,36 @@ settingsEvaluated {
 }
 ```
 
+To use the Bearer token method instead, replace each `credentials` block in the examples above
+with the following.
+
+Groovy DSL:
+
+```gradle
+authentication {
+    header(HttpHeaderAuthentication)
+}
+credentials(HttpHeaderCredentials) {
+    name = "Authorization"
+    value = "Bearer YOUR_JWT_TOKEN"
+}
+```
+
+Kotlin DSL (add the imports at the top of the init script):
+
+```kotlin
+import org.gradle.authentication.http.HttpHeaderAuthentication
+import org.gradle.kotlin.dsl.*
+
+// ...
+authentication {
+    create<HttpHeaderAuthentication>("header")
+}
+credentials(HttpHeaderCredentials::class) {
+    name = "Authorization"
+    value = "Bearer YOUR_JWT_TOKEN"
+}
+```
 
 ## Deploying Kagami to Cloud Foundry
 

--- a/src/main/java/am/ik/kagami/config/SecurityConfig.java
+++ b/src/main/java/am/ik/kagami/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package am.ik.kagami.config;
 
 import am.ik.kagami.KagamiProperties;
 import am.ik.kagami.KagamiProperties.AuthenticationType;
+import am.ik.kagami.token.web.BasicToBearerTokenResolver;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -11,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -25,8 +27,11 @@ import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 
 import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
@@ -42,6 +47,7 @@ class SecurityConfig {
 
 	@Bean
 	SecurityFilterChain securityFilterChain(HttpSecurity http, KagamiProperties properties) throws Exception {
+		AuthenticationEntryPoint artifactsEntryPoint = artifactsAuthenticationEntryPoint();
 		HttpSecurity security = http
 		// @formatter:off
 			.authorizeHttpRequests(authz -> {
@@ -62,8 +68,12 @@ class SecurityConfig {
 					.anyRequest().hasRole("USER");
 			})
 				// @formatter:on
-			.oauth2ResourceServer(oauth -> oauth.jwt(jwt -> {
-			}))
+			.oauth2ResourceServer(oauth -> oauth.bearerTokenResolver(new BasicToBearerTokenResolver())
+				.authenticationEntryPoint(artifactsEntryPoint)
+				.jwt(jwt -> {
+				}))
+			.exceptionHandling(exception -> exception.defaultAuthenticationEntryPointFor(artifactsEntryPoint,
+					PathPatternRequestMatcher.withDefaults().matcher("/artifacts/**")))
 			.csrf(csrf -> csrf.ignoringRequestMatchers("/artifacts/**", "/token"))
 			.logout(logout -> logout.logoutUrl("/logout")
 				.logoutSuccessUrl("/login?logout")
@@ -79,6 +89,21 @@ class SecurityConfig {
 				throw new IllegalStateException("Unsupported authentication type: " + authenticationType);
 		}
 		return security.build();
+	}
+
+	/**
+	 * Entry point for artifact endpoints that advertises the Basic authentication scheme
+	 * in addition to Bearer so that Maven clients configured with the standard
+	 * {@code <username>} / {@code <password>} server settings respond to the 401
+	 * challenge with Basic credentials, which are then resolved as a bearer token by
+	 * {@link BasicToBearerTokenResolver}.
+	 */
+	private static AuthenticationEntryPoint artifactsAuthenticationEntryPoint() {
+		BearerTokenAuthenticationEntryPoint bearerEntryPoint = new BearerTokenAuthenticationEntryPoint();
+		return (request, response, authException) -> {
+			bearerEntryPoint.commence(request, response, authException);
+			response.addHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"Kagami\"");
+		};
 	}
 
 	@Bean

--- a/src/main/java/am/ik/kagami/token/web/BasicToBearerTokenResolver.java
+++ b/src/main/java/am/ik/kagami/token/web/BasicToBearerTokenResolver.java
@@ -1,0 +1,49 @@
+package am.ik.kagami.token.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
+
+/**
+ * A {@link BearerTokenResolver} that also accepts HTTP Basic authentication whose
+ * password part is a JWT token. This allows the standard Maven {@code settings.xml}
+ * {@code <server>} configuration with {@code <username>} / {@code <password>} to be used
+ * for accessing private repositories. The username part is ignored and the password part
+ * is treated as the bearer token.
+ */
+public class BasicToBearerTokenResolver implements BearerTokenResolver {
+
+	private static final String BASIC_PREFIX = "Basic ";
+
+	private final BearerTokenResolver delegate = new DefaultBearerTokenResolver();
+
+	@Override
+	public String resolve(HttpServletRequest request) {
+		String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+		if (authorization != null && authorization.regionMatches(true, 0, BASIC_PREFIX, 0, BASIC_PREFIX.length())) {
+			return resolveFromBasic(authorization.substring(BASIC_PREFIX.length()));
+		}
+		return this.delegate.resolve(request);
+	}
+
+	private String resolveFromBasic(String encodedCredentials) {
+		byte[] decoded;
+		try {
+			decoded = Base64.getDecoder().decode(encodedCredentials.trim());
+		}
+		catch (IllegalArgumentException ignored) {
+			return null;
+		}
+		String credentials = new String(decoded, StandardCharsets.UTF_8);
+		int delimiter = credentials.indexOf(':');
+		if (delimiter < 0) {
+			return null;
+		}
+		String token = credentials.substring(delimiter + 1);
+		return token.isEmpty() ? null : token;
+	}
+
+}

--- a/src/test/java/am/ik/kagami/KagamiIntegrationTest.java
+++ b/src/test/java/am/ik/kagami/KagamiIntegrationTest.java
@@ -93,7 +93,8 @@ public class KagamiIntegrationTest {
 			.retrieve()
 			.toBodilessEntity();
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
-		assertThat(response.getHeaders()).containsEntry(HttpHeaders.WWW_AUTHENTICATE, List.of("Bearer"));
+		assertThat(response.getHeaders()).containsEntry(HttpHeaders.WWW_AUTHENTICATE,
+				List.of("Bearer", "Basic realm=\"Kagami\""));
 	}
 
 	@Test
@@ -113,6 +114,36 @@ public class KagamiIntegrationTest {
 	}
 
 	@Test
+	void getArtifactsShouldBeOkWithBasicAuthUsingTokenAsPassword() {
+		this.mockServer.GET("/am/ik/kagami/kagami/0.0.2/kagami-0.0.2.pom", req -> Response.ok("<project></project>"))
+			.GET("/am/ik/kagami/kagami/0.0.2/kagami-0.0.2.pom.sha1",
+					req -> Response.ok("147ddc4bbee044878ea3f8341a40e770e4b92f4e"));
+		String token = issueToken(List.of("mock"), List.of("artifacts:read"));
+		var response = this.restClient.get()
+			.uri("/artifacts/mock/am/ik/kagami/kagami/0.0.2/kagami-0.0.2.pom")
+			// The username part can be anything. The password part is the JWT token.
+			.headers(httpHeaders -> httpHeaders.setBasicAuth("anyuser", Objects.requireNonNull(token)))
+			.retrieve()
+			.toBodilessEntity();
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+	}
+
+	@Test
+	void getArtifactsShouldBeUnAuthorizedWithBasicAuthUsingInvalidPassword() {
+		var response = this.restClient.get()
+			.uri("/artifacts/mock/am/ik/kagami/kagami/0.0.1/kagami-0.0.1.pom")
+			.headers(httpHeaders -> httpHeaders.setBasicAuth("anyuser", "not-a-jwt"))
+			.retrieve()
+			.toBodilessEntity();
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+		assertThat(response.getHeaders()).hasEntrySatisfying(HttpHeaders.WWW_AUTHENTICATE, values -> {
+			assertThat(values).hasSize(2);
+			assertThat(values.getFirst()).contains("invalid_token");
+			assertThat(values.getLast()).isEqualTo("Basic realm=\"Kagami\"");
+		});
+	}
+
+	@Test
 	void getArtifactsShouldBeUnAuthorizedWithoutValidRepositories() {
 		String token = issueToken(List.of("another"), List.of("artifacts:read"));
 		var response = this.restClient.get()
@@ -122,7 +153,7 @@ public class KagamiIntegrationTest {
 			.toBodilessEntity();
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 		assertThat(response.getHeaders()).hasEntrySatisfying(HttpHeaders.WWW_AUTHENTICATE, values -> {
-			assertThat(values).hasSize(1);
+			assertThat(values).hasSize(2);
 			assertThat(values.getFirst())
 				.contains("Token does not contain the repository 'mock' in 'kagami:repositories' claim");
 		});
@@ -151,7 +182,8 @@ public class KagamiIntegrationTest {
 			.retrieve()
 			.toBodilessEntity();
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
-		assertThat(response.getHeaders()).containsEntry(HttpHeaders.WWW_AUTHENTICATE, List.of("Bearer"));
+		assertThat(response.getHeaders()).containsEntry(HttpHeaders.WWW_AUTHENTICATE,
+				List.of("Bearer", "Basic realm=\"Kagami\""));
 	}
 
 	@Test
@@ -183,7 +215,7 @@ public class KagamiIntegrationTest {
 			.toBodilessEntity();
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 		assertThat(response.getHeaders()).hasEntrySatisfying(HttpHeaders.WWW_AUTHENTICATE, values -> {
-			assertThat(values).hasSize(1);
+			assertThat(values).hasSize(2);
 			assertThat(values.getFirst())
 				.contains("Token does not contain the repository 'mock' in 'kagami:repositories' claim");
 		});

--- a/ui/src/components/RepositoryConfigDialog.tsx
+++ b/ui/src/components/RepositoryConfigDialog.tsx
@@ -3,7 +3,7 @@ import { Dialog, DialogHeader, DialogTitle, DialogClose, DialogContent } from '.
 import { Button } from './ui/Button';
 import { Copy, Check } from 'lucide-react';
 import type { RepositoryInfo } from '../types/api';
-import { generateConfigExample, type BuildTool } from '../utils/configExamples';
+import { generateConfigExample, type AuthMethod, type BuildTool } from '../utils/configExamples';
 
 interface RepositoryConfigDialogProps {
   open: boolean;
@@ -14,6 +14,7 @@ interface RepositoryConfigDialogProps {
 
 export function RepositoryConfigDialog({ open, onOpenChange, repository }: RepositoryConfigDialogProps) {
   const [selectedTool, setSelectedTool] = useState<BuildTool>('maven');
+  const [authMethod, setAuthMethod] = useState<AuthMethod>('basic');
   const [copiedConfig, setCopiedConfig] = useState<string | null>(null);
 
   if (!repository) return null;
@@ -26,7 +27,8 @@ export function RepositoryConfigDialog({ open, onOpenChange, repository }: Repos
       repositoryIds: [repository.id],
       token,
       baseUrl: window.location.origin,
-      isPrivate: repository.isPrivate
+      isPrivate: repository.isPrivate,
+      authMethod
     });
   };
 
@@ -86,6 +88,32 @@ export function RepositoryConfigDialog({ open, onOpenChange, repository }: Repos
               Gradle (Kotlin)
             </button>
           </div>
+
+          {/* Authentication Method Tabs (private repositories only) */}
+          {repository.isPrivate && (
+            <div className="flex space-x-1 bg-gray-100 rounded-lg p-1">
+              <button
+                className={`flex-1 py-2 px-3 text-sm font-medium rounded-md transition-colors ${
+                  authMethod === 'basic'
+                    ? 'bg-white text-red-700 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+                onClick={() => setAuthMethod('basic')}
+              >
+                Username / Password
+              </button>
+              <button
+                className={`flex-1 py-2 px-3 text-sm font-medium rounded-md transition-colors ${
+                  authMethod === 'bearer'
+                    ? 'bg-white text-red-700 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+                onClick={() => setAuthMethod('bearer')}
+              >
+                Bearer Token
+              </button>
+            </div>
+          )}
 
           {/* Repository Information */}
           <div className="bg-gray-50 rounded-lg p-4">

--- a/ui/src/pages/TokenPage.tsx
+++ b/ui/src/pages/TokenPage.tsx
@@ -7,7 +7,7 @@ import { Button } from '../components/ui/Button';
 import { LockIcon } from '../components/ui/LockIcon';
 import { Header } from '../components/Header';
 import { ArrowLeft, Copy, Key, Shield, Clock, AlertTriangle } from 'lucide-react';
-import { generateConfigExample, type BuildTool } from '../utils/configExamples';
+import { generateConfigExample, type AuthMethod, type BuildTool } from '../utils/configExamples';
 
 interface TokenFormData {
   repositories: string[];
@@ -30,6 +30,7 @@ export function TokenPage() {
   const [error, setError] = useState<string | null>(null);
   const [copySuccess, setCopySuccess] = useState<{ [key: string]: boolean }>({});
   const [selectedTool, setSelectedTool] = useState<BuildTool>('maven');
+  const [authMethod, setAuthMethod] = useState<AuthMethod>('basic');
 
   const availableScopes = [
     { value: 'artifacts:read', label: 'Read Artifacts', description: 'Download and view repository contents' },
@@ -122,6 +123,7 @@ export function TokenPage() {
     setError(null);
     setCopySuccess({});
     setSelectedTool('maven');
+    setAuthMethod('basic');
     setFormData({
       repositories: [],
       scopes: [],
@@ -388,6 +390,30 @@ export function TokenPage() {
                 </button>
               </div>
 
+              {/* Authentication Method Tabs */}
+              <div className="flex space-x-1 bg-gray-100 rounded-lg p-1 mb-4">
+                <button
+                  className={`flex-1 py-2 px-3 text-sm font-medium rounded-md transition-colors ${
+                    authMethod === 'basic'
+                      ? 'bg-white text-red-700 shadow-sm'
+                      : 'text-gray-600 hover:text-gray-900'
+                  }`}
+                  onClick={() => setAuthMethod('basic')}
+                >
+                  Username / Password
+                </button>
+                <button
+                  className={`flex-1 py-2 px-3 text-sm font-medium rounded-md transition-colors ${
+                    authMethod === 'bearer'
+                      ? 'bg-white text-red-700 shadow-sm'
+                      : 'text-gray-600 hover:text-gray-900'
+                  }`}
+                  onClick={() => setAuthMethod('bearer')}
+                >
+                  Bearer Token
+                </button>
+              </div>
+
               {/* Selected Configuration */}
               <div className="border border-gray-200 rounded-lg">
                 {(() => {
@@ -395,7 +421,8 @@ export function TokenPage() {
                     repositoryIds: formData.repositories,
                     token: generatedToken!,
                     baseUrl: window.location.origin,
-                    isPrivate: true
+                    isPrivate: true,
+                    authMethod
                   };
                   const config = generateConfigExample(selectedTool, params);
 

--- a/ui/src/utils/configExamples.ts
+++ b/ui/src/utils/configExamples.ts
@@ -6,25 +6,22 @@ export interface ConfigExample {
   filename: string;
 }
 
+// 'basic': standard username/password credentials (username is arbitrary, password is the JWT token)
+// 'bearer': Authorization Bearer header with the JWT token
+export type AuthMethod = 'basic' | 'bearer';
+
 export interface ConfigExamplesParams {
   repositoryIds: string[];
   token: string;
   baseUrl: string;
   isPrivate?: boolean;
+  authMethod?: AuthMethod;
 }
 
-export function generateMavenConfig({ repositoryIds, token, baseUrl, isPrivate = true }: ConfigExamplesParams): ConfigExample {
-  const primaryRepo = repositoryIds[0];
-  
-  if (repositoryIds.length === 1) {
-    return {
-      title: 'Maven Configuration',
-      filename: '$HOME/.m2/settings.xml',
-      content: `<!-- RECOMMENDED: Add to your $HOME/.m2/settings.xml -->
-<settings>
-${isPrivate ? `  <servers>
-    <server>
-      <id>kagami-${primaryRepo}</id>
+function mavenServer(repo: string, token: string, authMethod: AuthMethod): string {
+  if (authMethod === 'bearer') {
+    return `    <server>
+      <id>kagami-${repo}</id>
       <configuration>
         <httpHeaders>
           <property>
@@ -33,9 +30,81 @@ ${isPrivate ? `  <servers>
           </property>
         </httpHeaders>
       </configuration>
-    </server>
+    </server>`;
+  }
+  return `    <server>
+      <id>kagami-${repo}</id>
+      <username>kagami</username>
+      <password>${token}</password>
+    </server>`;
+}
+
+function mavenServersSection(repositoryIds: string[], token: string, authMethod: AuthMethod): string {
+  const comment = authMethod === 'basic'
+    ? '    <!-- The username can be any value. The password is the JWT token. -->\n'
+    : '';
+  return `  <servers>
+${comment}${repositoryIds.map(repo => mavenServer(repo, token, authMethod)).join('\n')}
   </servers>
-` : ''}  <profiles>
+`;
+}
+
+function gradleGroovyCredentials(indent: string, authMethod: AuthMethod): string {
+  if (authMethod === 'bearer') {
+    return `
+${indent}authentication {
+${indent}    header(HttpHeaderAuthentication)
+${indent}}
+${indent}credentials(HttpHeaderCredentials) {
+${indent}    name = "Authorization"
+${indent}    value = repoToken
+${indent}}`;
+  }
+  return `
+${indent}credentials {
+${indent}    username = "kagami" // can be any value
+${indent}    password = repoToken
+${indent}}`;
+}
+
+function gradleKotlinCredentials(indent: string, authMethod: AuthMethod): string {
+  if (authMethod === 'bearer') {
+    return `
+${indent}authentication {
+${indent}    create<HttpHeaderAuthentication>("header")
+${indent}}
+${indent}credentials(HttpHeaderCredentials::class) {
+${indent}    name = "Authorization"
+${indent}    value = repoToken
+${indent}}`;
+  }
+  return `
+${indent}credentials {
+${indent}    username = "kagami" // can be any value
+${indent}    password = repoToken
+${indent}}`;
+}
+
+function gradleTokenValue(token: string, authMethod: AuthMethod): string {
+  return authMethod === 'bearer' ? `Bearer ${token}` : token;
+}
+
+const GRADLE_KOTLIN_BEARER_IMPORTS = `import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.authentication.http.HttpHeaderAuthentication
+import org.gradle.kotlin.dsl.*
+
+`;
+
+export function generateMavenConfig({ repositoryIds, token, baseUrl, isPrivate = true, authMethod = 'basic' }: ConfigExamplesParams): ConfigExample {
+  const primaryRepo = repositoryIds[0];
+
+  if (repositoryIds.length === 1) {
+    return {
+      title: 'Maven Configuration',
+      filename: '$HOME/.m2/settings.xml',
+      content: `<!-- RECOMMENDED: Add to your $HOME/.m2/settings.xml -->
+<settings>
+${isPrivate ? mavenServersSection([primaryRepo], token, authMethod) : ''}  <profiles>
     <profile>
       <id>kagami-${primaryRepo}</id>
       <activation>
@@ -99,20 +168,7 @@ ${isPrivate ? `  <servers>
       filename: '$HOME/.m2/settings.xml',
       content: `<!-- RECOMMENDED: Add to your $HOME/.m2/settings.xml -->
 <settings>
-${isPrivate ? `  <servers>
-${repositoryIds.map(repo => `    <server>
-      <id>kagami-${repo}</id>
-      <configuration>
-        <httpHeaders>
-          <property>
-            <name>Authorization</name>
-            <value>Bearer ${token}</value>
-          </property>
-        </httpHeaders>
-      </configuration>
-    </server>`).join('\n')}
-  </servers>
-` : ''}  <profiles>
+${isPrivate ? mavenServersSection(repositoryIds, token, authMethod) : ''}  <profiles>
     <profile>
       <id>kagami-multiple</id>
       <activation>
@@ -164,9 +220,9 @@ ${repositoryIds.map(repo => `        <pluginRepository>
   }
 }
 
-export function generateGradleGroovyConfig({ repositoryIds, token, baseUrl, isPrivate = true }: ConfigExamplesParams): ConfigExample {
+export function generateGradleGroovyConfig({ repositoryIds, token, baseUrl, isPrivate = true, authMethod = 'basic' }: ConfigExamplesParams): ConfigExample {
   const isHttpUrl = baseUrl.startsWith('http://');
-  
+
   if (repositoryIds.length === 1) {
     const repo = repositoryIds[0];
     return {
@@ -175,21 +231,14 @@ export function generateGradleGroovyConfig({ repositoryIds, token, baseUrl, isPr
       content: `// $HOME/.gradle/init.gradle - Groovy DSL version
 
 def repoUrl = "${baseUrl}/artifacts/${repo}"
-def repoToken = "Bearer ${token}"
+def repoToken = "${gradleTokenValue(token, authMethod)}"
 
 // For regular dependencies (legacy projects)
 allprojects {
     repositories {
         maven {
             url = repoUrl${isHttpUrl ? `
-            allowInsecureProtocol = true` : ''}${isPrivate ? `
-            authentication {
-                header(HttpHeaderAuthentication)
-            }
-            credentials(HttpHeaderCredentials) {
-                name = "Authorization"
-                value = repoToken
-            }` : ''}
+            allowInsecureProtocol = true` : ''}${isPrivate ? gradleGroovyCredentials('            ', authMethod) : ''}
         }
         mavenCentral() // fallback
     }
@@ -202,36 +251,22 @@ settingsEvaluated { settings ->
         repositories {
             maven {
                 url = repoUrl${isHttpUrl ? `
-                allowInsecureProtocol = true` : ''}${isPrivate ? `
-                authentication {
-                    header(HttpHeaderAuthentication)
-                }
-                credentials(HttpHeaderCredentials) {
-                    name = "Authorization"
-                    value = repoToken
-                }` : ''}
+                allowInsecureProtocol = true` : ''}${isPrivate ? gradleGroovyCredentials('                ', authMethod) : ''}
             }
             gradlePluginPortal() // fallback
             mavenCentral() // fallback
         }
     }
-    
+
     // Dependency resolution management (Gradle 6.8+)
     settings.dependencyResolutionManagement {
         // Ignore repositories defined in build.gradle
         repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
-        
+
         repositories {
             maven {
                 url = repoUrl${isHttpUrl ? `
-                allowInsecureProtocol = true` : ''}${isPrivate ? `
-                authentication {
-                    header(HttpHeaderAuthentication)
-                }
-                credentials(HttpHeaderCredentials) {
-                    name = "Authorization"
-                    value = repoToken
-                }` : ''}
+                allowInsecureProtocol = true` : ''}${isPrivate ? gradleGroovyCredentials('                ', authMethod) : ''}
             }
             mavenCentral() // fallback
         }
@@ -246,20 +281,13 @@ settingsEvaluated { settings ->
 
 // Repository configurations
 ${repositoryIds.map(repo => `def ${repo}Url = "${baseUrl}/artifacts/${repo}"`).join('\n')}
-def repoToken = "Bearer ${token}"
+def repoToken = "${gradleTokenValue(token, authMethod)}"
 
 // Extension method to add repositories
 def addKagamiRepositories = { repos ->
 ${repositoryIds.map(repo => `    repos.maven {
         url = ${repo}Url${isHttpUrl ? `
-        allowInsecureProtocol = true` : ''}${isPrivate ? `
-        authentication {
-            header(HttpHeaderAuthentication)
-        }
-        credentials(HttpHeaderCredentials) {
-            name = "Authorization"
-            value = repoToken
-        }` : ''}
+        allowInsecureProtocol = true` : ''}${isPrivate ? gradleGroovyCredentials('        ', authMethod) : ''}
     }`).join('\n    ')}
     repos.mavenCentral() // fallback
 }
@@ -280,12 +308,12 @@ settingsEvaluated { settings ->
             gradlePluginPortal() // fallback
         }
     }
-    
+
     // Dependency resolution management (Gradle 6.8+)
     settings.dependencyResolutionManagement {
         // Ignore repositories defined in build.gradle
         repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
-        
+
         repositories {
             addKagamiRepositories(delegate)
         }
@@ -295,9 +323,10 @@ settingsEvaluated { settings ->
   }
 }
 
-export function generateGradleKotlinConfig({ repositoryIds, token, baseUrl, isPrivate = true }: ConfigExamplesParams): ConfigExample {
+export function generateGradleKotlinConfig({ repositoryIds, token, baseUrl, isPrivate = true, authMethod = 'basic' }: ConfigExamplesParams): ConfigExample {
   const isHttpUrl = baseUrl.startsWith('http://');
-  
+  const imports = authMethod === 'bearer' ? GRADLE_KOTLIN_BEARER_IMPORTS : '';
+
   if (repositoryIds.length === 1) {
     const repo = repositoryIds[0];
     return {
@@ -305,25 +334,14 @@ export function generateGradleKotlinConfig({ repositoryIds, token, baseUrl, isPr
       filename: '$HOME/.gradle/init.gradle.kts',
       content: `// $HOME/.gradle/init.gradle.kts - Kotlin DSL version
 
-import org.gradle.api.artifacts.repositories.PasswordCredentials
-import org.gradle.authentication.http.HttpHeaderAuthentication
-import org.gradle.kotlin.dsl.*
-
-val repoUrl = "${baseUrl}/artifacts/${repo}"
-val repoToken = "Bearer ${token}"
+${imports}val repoUrl = "${baseUrl}/artifacts/${repo}"
+val repoToken = "${gradleTokenValue(token, authMethod)}"
 
 // Extension function to configure repository
 fun RepositoryHandler.addKagamiRepository() {
     maven {
         url = uri(repoUrl)${isHttpUrl ? `
-        isAllowInsecureProtocol = true` : ''}${isPrivate ? `
-        authentication {
-            create<HttpHeaderAuthentication>("header")
-        }
-        credentials(HttpHeaderCredentials::class) {
-            name = "Authorization"
-            value = repoToken
-        }` : ''}
+        isAllowInsecureProtocol = true` : ''}${isPrivate ? gradleKotlinCredentials('        ', authMethod) : ''}
     }
 }
 
@@ -345,13 +363,13 @@ settingsEvaluated {
             mavenCentral() // fallback
         }
     }
-    
+
     // Dependency resolution management (Gradle 6.8+)
     dependencyResolutionManagement {
         // Ignore repositories defined in build.gradle
         @Suppress("UnstableApiUsage")
         repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
-        
+
         repositories {
             addKagamiRepository()
             mavenCentral() // fallback
@@ -365,26 +383,15 @@ settingsEvaluated {
       filename: '$HOME/.gradle/init.gradle.kts',
       content: `// $HOME/.gradle/init.gradle.kts - Kotlin DSL version
 
-import org.gradle.api.artifacts.repositories.PasswordCredentials
-import org.gradle.authentication.http.HttpHeaderAuthentication
-import org.gradle.kotlin.dsl.*
-
-// Repository configurations
+${imports}// Repository configurations
 ${repositoryIds.map(repo => `val ${repo}Url = "${baseUrl}/artifacts/${repo}"`).join('\n')}
-val repoToken = "Bearer ${token}"
+val repoToken = "${gradleTokenValue(token, authMethod)}"
 
 // Extension function to configure Kagami repositories
 fun RepositoryHandler.addKagamiRepositories() {
 ${repositoryIds.map(repo => `    maven {
         url = uri(${repo}Url)${isHttpUrl ? `
-        isAllowInsecureProtocol = true` : ''}${isPrivate ? `
-        authentication {
-            create<HttpHeaderAuthentication>("header")
-        }
-        credentials(HttpHeaderCredentials::class) {
-            name = "Authorization"
-            value = repoToken
-        }` : ''}
+        isAllowInsecureProtocol = true` : ''}${isPrivate ? gradleKotlinCredentials('        ', authMethod) : ''}
     }`).join('\n    ')}
     mavenCentral() // fallback
 }
@@ -405,13 +412,13 @@ settingsEvaluated {
             gradlePluginPortal() // fallback
         }
     }
-    
+
     // Dependency resolution management (Gradle 6.8+)
     dependencyResolutionManagement {
         // Ignore repositories defined in build.gradle
         @Suppress("UnstableApiUsage")
         repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
-        
+
         repositories {
             addKagamiRepositories()
         }


### PR DESCRIPTION
## Summary

Allow accessing private repositories with the standard Maven/Gradle username/password configuration, in addition to the existing `Authorization: Bearer` header method. The username can be any value and the password is the JWT token:

```xml
<server>
  <id>kagami-private</id>
  <username>any-username</username>
  <password>YOUR_JWT_TOKEN</password>
</server>
```

## Changes

### Backend

- **`BasicToBearerTokenResolver`** (new): a `BearerTokenResolver` that resolves the password part of HTTP Basic authentication as a bearer token. The username part is ignored. Regular `Bearer` headers are delegated to `DefaultBearerTokenResolver`, so the existing method keeps working.
- **`SecurityConfig`**: 401 responses for `/artifacts/**` now advertise `Basic realm="Kagami"` in `WWW-Authenticate` in addition to `Bearer`. This is required because Maven and Gradle send credentials only in response to a challenge that includes the `Basic` scheme. The entry point is wired into both the resource server (token present but invalid) and `exceptionHandling` (no token), as those two cases take different paths.

### Frontend

- Token page and repository config dialog now have authentication method tabs (**Username / Password** | **Bearer Token**) for the generated configuration examples. Default is Username/Password.
- Config example generators support both methods for Maven, Gradle Groovy DSL, and Gradle Kotlin DSL.

### Docs

- README documents both authentication methods for Maven and Gradle.

## Verification

- All 24 backend tests pass, including new integration tests for Basic auth with the token as password (success and invalid-password cases).
- Verified end-to-end against a local Kagami server (private repo mirroring Maven Central) with a real JWT token:
  - `mvn dependency:get` with `<username>/<password>` in `settings.xml` (mirror of `*`, empty local repo): all artifacts downloaded through Kagami
  - Gradle 9.4.1 with standard `credentials { username/password }` in `settings.gradle.kts` and with init scripts identical to the generated samples (both Groovy and Kotlin DSL): resolved through Kagami
  - Invalid password fails with 401 in both tools
  - Existing Bearer `httpHeaders` configuration still works (regression check)
  - UI tabs verified in the browser: default shows username/password, switching to Bearer Token shows the header-based config, selection is kept across build tool tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)